### PR TITLE
Specify tensorflow version in readme and setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Requirements
 
 * `Python <https://www.python.org>`_ 3.6+
 * `TreeLib <https://treelib.readthedocs.io>`_ 1.5+
-* `Tensorflow <https://www.tensorflow.org/>`_ <2
+* `Tensorflow <https://www.tensorflow.org/>`_ 1.15
 * `CkipTagger <https://pypi.org/project/ckiptagger>`_ 0.1.1+ [Optional, Recommended]
 * `CkipClassic <https://ckip-classic.readthedocs.io>`_ 1.0+ [Optional]
 

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Requirements
 
 * `Python <https://www.python.org>`_ 3.6+
 * `TreeLib <https://treelib.readthedocs.io>`_ 1.5+
-
+* `Tensorflow <https://www.tensorflow.org/>`_ <2
 * `CkipTagger <https://pypi.org/project/ckiptagger>`_ 0.1.1+ [Optional, Recommended]
 * `CkipClassic <https://ckip-classic.readthedocs.io>`_ 1.0+ [Optional]
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ def main():
             'appdirs>=1.4.3',
             'numpy>=1.18',
             'treelib>=1.5.5',
+            'tensorflow==1.15'
         ],
         extras_require={
             # 'classic': ['ckip-classic>=1.0'],


### PR DESCRIPTION
I was trying out `ckipnlp` with latest tensorflow (`2.2.0`), and when doing `doc = CkipDocument(raw='中文字喔，啊哈哈哈')`, I got the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckipnlp/pipeline/core.py", line 206, in get_ws
    text=self.get_text(doc)
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckipnlp/driver/base.py", line 88, in __call__
    self.init()
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckipnlp/driver/base.py", line 84, in init
    self._init()
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckipnlp/driver/tagger.py", line 80, in _init
    self._core = ckiptagger.WS(_get_tagger_data(), disable_cuda=self._disable_cuda)
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckiptagger/api.py", line 52, in __init__
    model = model_ws.Model(config)
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckiptagger/model_ws.py", line 212, in __init__
    self.create_embedding()
  File "/Users/wyw/anaconda3/envs/ckip/lib/python3.7/site-packages/ckiptagger/model_ws.py", line 227, in create_embedding
    with tf.variable_scope(self.name, initializer=tf.random_normal_initializer(stddev=0.1)):
AttributeError: module 'tensorflow' has no attribute 'variable_scope'
```
After some googling I think the issue is that tensorflow has a major reform in r2.0. Afer downgradeing to `tensorflow 1.15`, I no longer got the error and can use `ckipnlp` without problem. Therefore I suggest adding the tensorflow version to `README` and `setup.py` to help other new users like myself. 